### PR TITLE
sc-55961: Do not generate atlantis.yml file if no paths match glob pa…

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -592,8 +592,14 @@ func getAllTerragruntFiles(path string) ([]string, error) {
 	if filterPath != "" && len(projectHclFiles) == 0 {
 		// get all matching folders
 		workingPaths, err = filepathx.Glob(filterPath)
+
 		if err != nil {
 			return nil, err
+		}
+
+		if len(workingPaths) == 0 {
+		  log.Info("Exiting since NO PATHS found for glob patter: ", filterPath)
+		  return nil, err
 		}
 	}
 
@@ -708,6 +714,10 @@ func main(cmd *cobra.Command, args []string) error {
 		terragruntFiles, err := getAllTerragruntFiles(workingDir)
 		if err != nil {
 			return err
+		}
+
+		if len(terragruntFiles) == 0 {
+			return nil
 		}
 
 		if len(projectHclDirs) == 0 || createHclProjectChilds || (createHclProjectExternalChilds && workingDir == gitRoot) {


### PR DESCRIPTION
# Pull Request


## Description

Currently if no paths match glob passed in --filter atlantis.yaml is still generated and then atlantis plan is executed for **all** paths. We want to exit early and do **NOT** generate atlantis.yaml file if no paths match filter to avoid executing atlantis plan for all files

### version 1.16.1

I did not want to produce 1.16.2 version since we would have to produce an entire new docker image that points to that version. I think this is still in development/experimental phase and staying with 1.16.1 is good enough for now


### Tests

Tested locally:

```
➜  terragrunt-atlantis-config git:(piotrkala/sc-55961/do-not-generate-atlantis-yaml-if-no-paths) ~/terragrunt-atlantis-config_1.16.2_linux_amd64/terragrunt-atlantis-config_1.16.2_linux_amd64 generate --output atlantis.yaml --autoplan --filter 'src/**/dev/**' --parallel=false
INFO[0000] Could not find an old config file. Starting from scratch 
INFO[0000] No paths found for glob patter: src/**/dev/** 
```

NO atlantis.yaml file was generated!